### PR TITLE
Desafio 2

### DIFF
--- a/src/main/java/co/com/techskill/lab2/library/web/PetitionResource.java
+++ b/src/main/java/co/com/techskill/lab2/library/web/PetitionResource.java
@@ -2,18 +2,23 @@ package co.com.techskill.lab2.library.web;
 
 import co.com.techskill.lab2.library.domain.dto.PetitionDTO;
 import co.com.techskill.lab2.library.service.IPetitionService;
+import co.com.techskill.lab2.library.service.dummy.PetitionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+
 @RestController
 @RequestMapping("/petitions")
 public class PetitionResource {
     private final IPetitionService petitionService;
+    private final PetitionService dummyPetitionService;
 
-    public PetitionResource(IPetitionService petitionService){
+   public PetitionResource(IPetitionService petitionService,
+                            PetitionService dummyPetitionService) {
         this.petitionService = petitionService;
+        this.dummyPetitionService = dummyPetitionService;
     }
 
     @GetMapping("/all")
@@ -44,5 +49,12 @@ public class PetitionResource {
     @PostMapping("/revisar")
     public Flux<String> checkPetitions(@RequestBody PetitionDTO petitionDTO) {
         return petitionService.checkPriorities(petitionDTO);
+    }
+
+    @GetMapping("/reto2")
+    public Flux<String> runReto2() {
+        return dummyPetitionService.reto2()
+                .doOnSubscribe(s -> System.out.println("=== [Reto 2] start ==="))
+                .doOnComplete(() -> System.out.println("=== [Reto 2] complete ==="));
     }
 }


### PR DESCRIPTION
Desafío 2 – Resiliencia en flujos RETURN
Cambios clave

Se añadió el método reto2() en PetitionService:
Validación de negocio: rechaza peticiones RETURN con más de 3 días.
Timeout: 500 ms por operación.
Retry selectivo: hasta 2 intentos para fallos transitorios o timeouts.
Fallback: mensajes controlados en caso de error.
Endpoint /petitions/reto2 agregado en PetitionResource.

Prueba Postman
Método: GET
URL: http://localhost:8080/petitions/reto2
Respuesta esperada:
<img width="1199" height="818" alt="image" src="https://github.com/user-attachments/assets/d2b2f5b1-7902-4070-870a-1afce7bfe325" />
