### PR TITLE
Entrega Laboratorio 2

### DIFF
--- a/src/main/java/co/com/techskill/lab2/library/service/dummy/PetitionService.java
+++ b/src/main/java/co/com/techskill/lab2/library/service/dummy/PetitionService.java
@@ -1,13 +1,18 @@
 package co.com.techskill.lab2.library.service.dummy;
 
 import co.com.techskill.lab2.library.domain.dto.PetitionDTO;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 public class PetitionService {
@@ -49,4 +54,47 @@ public class PetitionService {
     }
 
     //TO - DO: Challenge #1
+
+    public Flux<PetitionDTO> changeDatePetitions(){
+
+        return Flux.fromIterable(petitions)
+                .map(p -> {
+                    int diasAleatorios = ThreadLocalRandom.current().nextInt(1, 6); // 1 a 5
+                    p.setSentAt(LocalDate.now().minusDays(diasAleatorios));;
+                    p.setType("RETURN");
+                    return p;
+                });
+    }
+
+    public Flux<PetitionDTO> errorSimulator(){
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("petitionService");
+
+        return changeDatePetitions()
+                .flatMap(petition -> Mono.just(petition)
+                        .transformDeferred(CircuitBreakerOperator.of(circuitBreaker))
+                        .flatMap(p -> {
+
+                            System.out.println("RETURN".equalsIgnoreCase(p.getType()));
+                            System.out.println(LocalDate.now());
+                            System.out.println(p.getSentAt());
+                            System.out.println(p.getSentAt().isBefore(LocalDate.now().minusDays(3)));
+
+                            if ("RETURN".equalsIgnoreCase(p.getType()) &&
+                                    p.getSentAt().isBefore(LocalDate.now().minusDays(3))) {
+                                System.out.println("RETURN con más de 3 días de envío: " + p.getSentAt());
+                                return Mono.error(new RuntimeException("RETURN con más de 3 días de envío: " + p.getSentAt()));
+                            }
+                            return Mono.just(p);
+                        })
+                        .retry(2) 
+                        .timeout(Duration.ofSeconds(2))
+                        .onErrorResume(error -> {
+                            System.out.println("Error controlado en petición " + petition.getPetitionId() + ": " + error.getMessage());
+                            return Mono.empty();
+                        })
+                );
+
+    }
+
+
 }

--- a/src/main/java/co/com/techskill/lab2/library/service/impl/PetitionServiceImpl.java
+++ b/src/main/java/co/com/techskill/lab2/library/service/impl/PetitionServiceImpl.java
@@ -7,6 +7,7 @@ import co.com.techskill.lab2.library.repository.IBookRepository;
 import co.com.techskill.lab2.library.repository.IPetitionRepository;
 import co.com.techskill.lab2.library.service.IPetitionService;
 
+import co.com.techskill.lab2.library.service.dummy.PetitionService;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
@@ -28,6 +29,7 @@ public class PetitionServiceImpl implements IPetitionService {
     private final IBookRepository bookRepository;
     private final PetitionMapper petitionMapper;
     CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("petitionService");
+    private PetitionService petitionService;
 
     public PetitionServiceImpl(IPetitionRepository petitionRepository, IBookRepository bookRepository) {
         this.petitionRepository = petitionRepository;
@@ -82,11 +84,9 @@ public class PetitionServiceImpl implements IPetitionService {
                 .switchIfEmpty(Mono.error(new RuntimeException("Petition of type LEND not found")))
                 .flatMap(petition -> bookRepository.findByBookId(petition.getBookId())
                         .map(book -> "Petition approved for book: " + book.getBookId())
-
                 ).onErrorResume(e -> Mono.just("Petition failed for book: " + petitionDTO.getBookId() + e.getMessage()));
 
     }
-
 
     @Override
     public Mono<String> simulateIntermittency(PetitionDTO petitionDTO) {
@@ -106,5 +106,7 @@ public class PetitionServiceImpl implements IPetitionService {
                 .onErrorResume(e -> Mono.just("Petition failed: "+petitionDTO.getPetitionId() + " - " + e.getMessage()));
 
     }
+
+
 
 }

--- a/src/main/java/co/com/techskill/lab2/library/web/PetitionResource.java
+++ b/src/main/java/co/com/techskill/lab2/library/web/PetitionResource.java
@@ -2,6 +2,7 @@ package co.com.techskill.lab2.library.web;
 
 import co.com.techskill.lab2.library.domain.dto.PetitionDTO;
 import co.com.techskill.lab2.library.service.IPetitionService;
+import co.com.techskill.lab2.library.service.dummy.PetitionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
@@ -11,7 +12,7 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/petitions")
 public class PetitionResource {
     private final IPetitionService petitionService;
-
+    private PetitionService petitionServiceDummy;
     public PetitionResource(IPetitionService petitionService){
         this.petitionService = petitionService;
     }

--- a/src/main/java/co/com/techskill/lab2/library/web/dummy/PetitionDummyResource.java
+++ b/src/main/java/co/com/techskill/lab2/library/web/dummy/PetitionDummyResource.java
@@ -1,0 +1,35 @@
+package co.com.techskill.lab2.library.web.dummy;
+
+import co.com.techskill.lab2.library.domain.dto.PetitionDTO;
+import co.com.techskill.lab2.library.service.dummy.PetitionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/dummy/petitions")
+public class PetitionDummyResource {
+    private final PetitionService petitionService;
+
+    public PetitionDummyResource(PetitionService petitionService) {
+        this.petitionService = petitionService;
+    }
+
+    @GetMapping("/all")
+    public Flux<PetitionDTO> getAllPetitions(){
+        return petitionService.dummyFindAll();
+    }
+
+    @GetMapping("/errorManageSimulator")
+    public Flux<PetitionDTO> getAllPetitionsSimulator(){
+        System.out.println("Entro al EndPoint /dummy/petitions/petitionsSimulator");
+        return petitionService.errorSimulator();
+    }
+
+    @PostMapping("/id")
+    public Mono<ResponseEntity<PetitionDTO>> findByPetitionId(@RequestBody PetitionDTO petitionDTO){
+        return petitionService.dummyFindById(petitionDTO.getPetitionId())
+                .map(ResponseEntity::ok);
+    }
+}


### PR DESCRIPTION
Laboratorio 2: John Jairo Lancheros Rangel.
 Se agrega el PetitionDummyResource y el @GetMapping("/errorManageSimulator") para simular la generación de errores.

<img width="1373" height="786" alt="image" src="https://github.com/user-attachments/assets/b0aec1ca-7fa8-4156-81ff-44b0046fcdc1" />

En el Petition Service se agregan dos métodos, changeDatePetitions, donde se actualizan las fechas de las peticiones con una aleatorio de días teniendo en cuenta la fecha actual con el fin de simular que una petición lleva varios días activa y se asigna a todas el tipo RETURN con el fin de ver como se hace el manejo por consola.

<img width="1288" height="292" alt="image" src="https://github.com/user-attachments/assets/18c9c1ab-2765-4237-824b-e55ccbc10948" />

Y en este otro método errorSimulator, se simula el flujo de manejo de los errores: 
<img width="1433" height="827" alt="image" src="https://github.com/user-attachments/assets/671b6159-1a00-413b-8e61-a733675d456f" />

Al ejecutar el Controller mediante PostMan se evidencia que las peticiones devueltas corresponden a peticiones de tipo RETURN y que las fechas sentAnt son menores a 3 días, es decir, se procesan.
<img width="1393" height="881" alt="image" src="https://github.com/user-attachments/assets/fe3d61d3-56b5-41e7-8dbe-91987cea25ad" />

Por el lado de la consola se realiza el manejo de errores, donde se evidencia que las peticiones que tienen un sentAt de más de 3 días se manejan mediante un sout por consola:
<img width="1275" height="318" alt="image" src="https://github.com/user-attachments/assets/90162834-c17a-4f15-ae49-f3408446f6a1" />


